### PR TITLE
Make "nodes" accessible from outside the package

### DIFF
--- a/lib/mustache.dart
+++ b/lib/mustache.dart
@@ -1,4 +1,5 @@
 import 'src/template.dart' as t;
+import 'src/node.dart';
 
 /// A Template can be efficiently rendered multiple times with different
 /// values.
@@ -16,6 +17,7 @@ abstract class Template {
 
   String get name;
   String get source;
+  List<Node> get nodes;
 
   /// [values] can be a combination of Map, List, String. Any non-String object
   /// will be converted using toString(). Null values will cause a

--- a/lib/src/template.dart
+++ b/lib/src/template.dart
@@ -29,6 +29,9 @@ class Template implements m.Template {
   String get name => _name;
 
   @override
+  List<Node> get nodes => _nodes;
+  
+  @override
   String renderString(values) {
     var buf = StringBuffer();
     render(values, buf);


### PR DESCRIPTION
Hi and thanks for maintaining the package.

I found a minor helpful change by making the "nodes" accessible from outside the package.

I had to change this, to let the user of my app see which variables exist in a template and fill all of them dynamically.

Does this make sense? Or is there another way to solve this?

Thanks,
Matthias
