### PR TITLE
Experimental hack to unify mustache and mustache_template libraries

### DIFF
--- a/lib/mustache.dart
+++ b/lib/mustache.dart
@@ -12,7 +12,8 @@ abstract class Template {
       bool htmlEscapeValues,
       String name,
       PartialResolver partialResolver,
-      String delimiters}) = t.Template.fromSource;
+      String delimiters,
+      ValueResolver valueResolver}) = t.Template.fromSource;
 
   String get name;
   String get source;
@@ -29,6 +30,27 @@ abstract class Template {
 }
 
 typedef PartialResolver = Template Function(String);
+
+const Object noSuchProperty = Object();
+
+typedef ValueResolver = Object Function(Object, Object);
+
+final RegExp _integerTag = RegExp(r'^[0-9]+$');
+
+//FIXME should name be String??
+// Returns the property of the given object by name. For a map,
+// which contains the key name, this is object[name]. For other
+// objects, this is object.name or object.name(). If no property
+// by the given name exists, this method returns noSuchProperty.
+Object defaultValueResolver(Object object, Object name) {
+  if (object is Map && object.containsKey(name)) return object[name];
+
+  if (object is List && _integerTag.hasMatch(name)) {
+    return object[int.parse(name)];
+  }
+
+  return noSuchProperty;
+}
 
 typedef LambdaFunction = Object Function(LambdaContext context);
 

--- a/lib/mustache_with_mirrors.dart
+++ b/lib/mustache_with_mirrors.dart
@@ -1,0 +1,66 @@
+import 'dart:mirrors';
+
+export 'mustache.dart' hide Template;
+import 'mustache.dart' as m;
+import 'src/template.dart' as t;
+
+class Template extends t.Template {
+  Template(String source,
+      {bool lenient = false,
+      bool htmlEscapeValues = true,
+      String name,
+      m.PartialResolver partialResolver,
+      String delimiters = '{{ }}',
+      m.ValueResolver valueResolver})
+      : super.fromSource(source,
+            lenient: lenient,
+            htmlEscapeValues: htmlEscapeValues,
+            name: name,
+            partialResolver: partialResolver,
+            delimiters: delimiters,
+            valueResolver:
+            valueResolver ??
+                (lenient ? lenientMirrorValueResolver : mirrorValueResolver));
+}
+
+final RegExp _validTag = RegExp(r'^[0-9a-zA-Z\_\-\.]+$');
+final RegExp _integerTag = RegExp(r'^[0-9]+$');
+
+Object mirrorValueResolver(Object object, Object name) =>
+    _mirrorValueResolver(object, name, lenient: false);
+
+Object lenientMirrorValueResolver(Object object, Object name) =>
+    _mirrorValueResolver(object, name, lenient: true);
+
+//FIXME name should be string right?
+// Returns the property of the given object by name. For a map,
+// which contains the key name, this is object[name]. For other
+// objects, this is object.name or object.name(). If no property
+// by the given name exists, this method returns noSuchProperty.
+Object _mirrorValueResolver(Object object, Object name,
+    {bool lenient = false}) {
+  if (object is Map && object.containsKey(name)) return object[name];
+
+  if (object is List && _integerTag.hasMatch(name)) {
+    return object[int.parse(name)];
+  }
+
+  if (lenient && !_validTag.hasMatch(name)) return m.noSuchProperty;
+
+  var instance = reflect(object);
+  var field = instance.type.instanceMembers[Symbol(name)];
+  if (field == null) return m.noSuchProperty;
+
+  var invocation;
+  if ((field is VariableMirror) ||
+      ((field is MethodMirror) && (field.isGetter))) {
+    invocation = instance.getField(field.simpleName);
+  } else if ((field is MethodMirror) &&
+      (field.parameters.where((p) => !p.isOptional).isEmpty)) {
+    invocation = instance.invoke(field.simpleName, []);
+  }
+  if (invocation == null) {
+    return m.noSuchProperty;
+  }
+  return invocation.reflectee;
+}

--- a/lib/src/template.dart
+++ b/lib/src/template.dart
@@ -9,13 +9,15 @@ class Template implements m.Template {
       bool htmlEscapeValues = true,
       String name,
       m.PartialResolver partialResolver,
-      String delimiters = '{{ }}'})
+      String delimiters = '{{ }}',
+      m.ValueResolver valueResolver = m.defaultValueResolver})
       : source = source,
         _nodes = parser.parse(source, lenient, name, delimiters),
         _lenient = lenient,
         _htmlEscapeValues = htmlEscapeValues,
         _name = name,
-        _partialResolver = partialResolver;
+        _partialResolver = partialResolver,
+        _valueResolver = valueResolver;
 
   @override
   final String source;
@@ -24,6 +26,7 @@ class Template implements m.Template {
   final bool _htmlEscapeValues;
   final String _name;
   final m.PartialResolver _partialResolver;
+  final m.ValueResolver _valueResolver;
 
   @override
   String get name => _name;
@@ -38,7 +41,7 @@ class Template implements m.Template {
   @override
   void render(values, StringSink sink) {
     var renderer = Renderer(sink, [values], _lenient, _htmlEscapeValues,
-        _partialResolver, _name, '', source);
+        _partialResolver, _valueResolver, _name, '', source);
     renderer.render(_nodes);
   }
 }


### PR DESCRIPTION
Thanks for keeping the mustache/mustache_template packages going. I haven't had time to do any development on these for a while.

Here's a pull request which isn't intended for merging as-is, rather a proof of concept, to demonstrate an idea, and get feedback. (This is a 1hr hack, and I haven't even tried to run the code).

The idea is to provide a pluggable system for resolving values. And then to provide a separate dart file to import called 'mustache_with_mirrors.dart' which uses a mirrors resolver by default. The existing mustache_template code-path remains the same and does not import mirrors. Doing something like this would allow the same package to support both the mirrors, and non-mirrors approach.

I'm pretty sure there's a better way to do it this, but this was the first thing that came to mind.

Comments appreciated.

Cheers,
Greg.