### PR TITLE
Allow missing keys when inv and lenient=true

### DIFF
--- a/lib/src/renderer.dart
+++ b/lib/src/renderer.dart
@@ -43,7 +43,7 @@ class Renderer extends Visitor {
 
   void push(value) => _stack.add(value);
 
-  Object pop() => _stack.removeLast();
+  dynamic pop() => _stack.removeLast();
 
   void write(Object output) => sink.write(output.toString());
 


### PR DESCRIPTION
I encountered a bug where if a key wasn't listed in the map passed to renderString then an exception would be thrown even though lenient was true.

I've relaxed the type requirements of pop() method as this is where the exception as throwing since _stack can have dynamic values but the return value of pop() was non-nullable.

Now the inversion symbol {{^email2}}{{email}}{{/email2}} works as expected and prints the interpolated value of email.